### PR TITLE
Re-factor server tests to test database

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -4,67 +4,11 @@ const mongoose = require('mongoose');
 
 const mongoUri = 'mongodb://localhost/trafalgar';
 
-mongoose.connect(mongoUri);
+mongoose.connect(mongoUri, { useNewUrlParser: true });
 
 const db = mongoose.connection;
-db.on('error', console.error.bind(console, 'connection error!'));
-db.once('open', () => console.log('connected!'));
-
-const tripSchema = new mongoose.Schema({
-  id: { type: Number },
-  name: { type: String },
-  season: { type: String },
-  year: { type: Number },
-  imageUrl: { type: String },
-  days: { type: Number },
-  country: {
-    type: String,
-  },
-  cities: [{
-    type: String,
-  }],
-  descriptions: [{
-    type: String,
-  }],
-  nights: { type: Number },
-  meals: {
-    breakfasts: { type: Number },
-    lunches: { type: Number },
-    dinners: { type: Number },
-  },
-  the_trafalgar_difference: [{
-    type: String,
-  }],
-  sightseeing_highlights: [{
-    type: String,
-  }],
-  travel_highlights: [{
-    type: String,
-  }],
-});
-
-const Trip = mongoose.model('Trip', tripSchema);
-
-// // test trip for database:
-// const iconicNorth = new Trip({
-//   id: 1,
-//   name: 'Iconic North',
-//   season: 'Summer',
-//   year: 2020,
-//   imageUrl: 'https://www.trafalgar.com/-/media/Project/Trafalgar/Product/hero-images/Iconic-North-Summer-2020-w.webp?smartCrop=1&centreCrop=1&w=2600&h=800',
-//   days: 7,
-//   country: 'New Zealand',
-//   cities: ['Auckland', 'Tauranga', 'Matamata', 'Rotorua', 'Wellington', 'Blenheim', 'Picton'],
-// // eslint-disable-next-line max-len
-//   descriptions: ['BUBBLING MUD POOLS AND MĀORI CULTURE DEFINE THIS MEMORABLE ENCOUNTER WITH NEW ZEALANDS NORTH. EXPLORE AUCKLAND, ROTORUA AND WELLINGTON, WITH A STOP FOR LUNCH WITH A RETIRED CHAMPION JOCKEY.', 'Bubbling mud pools and Māori culture define this memorable encounter with New Zealands north. Explore Auckland, Rotorua and Wellington, with a stop for lunch with a retired champion jockey.'],
-//   nights: 6,
-//   meals: { breakfasts: 6, lunches: 1, dinners: 3 },
-//   the_trafalgar_difference: ['Connect with locals', 'dive into culture'],
-//   sightseeing_highlights: ['city tour', 'orientation', 'visit', 'view'],
-//   travel_highlights: ['audio headsets', 'handcrafted highlights'],
-// });
-
-// iconicNorth.save();
+// db.on('error', console.error.bind(console, 'connection error!'));
+// db.once('open', () => console.log('connected!'));
 
 
-module.exports = Trip;
+module.exports = db;

--- a/db/index.js
+++ b/db/index.js
@@ -7,8 +7,8 @@ const mongoUri = 'mongodb://localhost/trafalgar';
 mongoose.connect(mongoUri, { useNewUrlParser: true });
 
 const db = mongoose.connection;
-// db.on('error', console.error.bind(console, 'connection error!'));
-// db.once('open', () => console.log('connected!'));
+db.on('error', console.error.bind(console, 'connection error!'));
+db.once('open', () => console.log('connected!'));
 
 
 module.exports = db;

--- a/db/schema.js
+++ b/db/schema.js
@@ -1,0 +1,36 @@
+const mongoose = require('mongoose');
+
+const tripSchema = new mongoose.Schema({
+  id: { type: Number },
+  name: { type: String },
+  season: { type: String },
+  year: { type: Number },
+  imageUrl: { type: String },
+  days: { type: Number },
+  country: {
+    type: String,
+  },
+  cities: [{
+    type: String,
+  }],
+  descriptions: [{
+    type: String,
+  }],
+  nights: { type: Number },
+  meals: {
+    breakfasts: { type: Number },
+    lunches: { type: Number },
+    dinners: { type: Number },
+  },
+  the_trafalgar_difference: [{
+    type: String,
+  }],
+  sightseeing_highlights: [{
+    type: String,
+  }],
+  travel_highlights: [{
+    type: String,
+  }],
+});
+
+module.exports = mongoose.model('Trip', tripSchema);

--- a/db/seed.js
+++ b/db/seed.js
@@ -1,7 +1,10 @@
+/* eslint-disable no-unused-vars */
 /* eslint-disable no-console */
 const data = require('./data-generator.js');
 
-const Trip = require('./index.js');
+const db = require('./index.js');
+
+const Trip = require('./schema.js');
 
 
 // function to create a trip from random data

--- a/package.json
+++ b/package.json
@@ -1,11 +1,16 @@
 {
   "name": "searchbar",
+  "jest": {
+    "verbose": true,
+    "testEnvironment": "node",
+    "collectCoverage": true
+  },
   "version": "1.0.0",
   "description": "searchbar and misc. informational components for replicating Trafalgar page",
   "main": "server/index.js",
   "scripts": {
     "build": "webpack -d --watch",
-    "start": "nodemon server",
+    "start": "nodemon server/server.js",
     "seed": "node db/seed.js",
     "test": "jest"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "webpack -d --watch",
     "start": "nodemon server/server.js",
     "seed": "node db/seed.js",
-    "test": "jest"
+    "test": "jest --forceExit"
   },
   "repository": {
     "type": "git",

--- a/server/controllers.js
+++ b/server/controllers.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 /* eslint-disable max-len */
 const Trip = require('../db/schema.js');
 const db = require('../db/index.js');

--- a/server/controllers.js
+++ b/server/controllers.js
@@ -1,5 +1,6 @@
 /* eslint-disable max-len */
-const Trip = require('../db/index.js');
+const Trip = require('../db/schema.js');
+const db = require('../db/index.js');
 
 const controllers = {
   // for initial page load, we get all trips' name/season/year for displaying in search bar, and id for if a trip is selected by user

--- a/server/index.js
+++ b/server/index.js
@@ -3,7 +3,6 @@
 const express = require('express');
 
 const app = express();
-const port = 3003;
 
 const bodyParser = require('body-parser');
 const morgan = require('morgan');
@@ -23,4 +22,4 @@ app.use(morgan('dev'));
 app.use(express.static(path.join(__dirname, '../client/dist')));
 app.use('/api', router);
 
-app.listen(port, () => console.log(`listening on port ${port}!`));
+module.exports = app;

--- a/server/server.js
+++ b/server/server.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 const app = require('./index.js');
 
 const port = 3003;

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,5 @@
+const app = require('./index.js');
+
+const port = 3003;
+
+app.listen(port, () => console.log(`listening on port ${port}!`));

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-undef */
 // const mongodb = require('mongoose');
 const supertest = require('supertest');
-const chai = require('chai');
+// const chai = require('chai');
 
-const { expect } = chai;
+// const { expect } = chai;
 
 const app = require('../server/index.js');
 // const Trip = require('../db/schema.js');
@@ -58,16 +58,17 @@ const request = supertest(app);
 // });
 
 describe('server api', () => {
-  it('gets all the trips in the database', (done) => {
-    request
-      .get('/api/trips')
-      .expect(200);
+  it('gets all 100 trips in the database', async (done) => {
+    const response = await request.get('/api/trips');
+    expect(response.statusCode).toBe(200);
+    expect(response.body.length).toBe(100);
     done();
   });
-  it('gets a trip when passed a numerical id as a parameter', (done) => {
-    request
-      .get('/api/trips/5')
-      .expect(200);
+  it('gets a trip with a given id when passed that number as a parameter', async (done) => {
+    const response = await request.get('/api/trips/5');
+    expect(response.statusCode).toBe(200);
+    expect(response.body.length).toBe(1);
+    expect(response.body[0].id).toBe(5);
     done();
   });
 });

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,74 +1,59 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable max-len */
 /* eslint-disable no-undef */
-// const mongodb = require('mongoose');
+const mongoose = require('mongoose');
 const supertest = require('supertest');
-// const chai = require('chai');
-
-// const { expect } = chai;
 
 const app = require('../server/index.js');
-// const Trip = require('../db/schema.js');
+const Trip = require('../db/schema.js');
 
 const request = supertest(app);
 
-// const dbURI = 'mongodb://localhost/Trafalgartest';
+beforeAll(async () => {
+  const dbURI = 'mongodb://localhost/Trafalgarservertest';
+  await mongoose.connect(dbURI, { useNewUrlParser: true });
+});
 
-// const clearDB = function (done) {
-//   mongoose.connection.collections.trips.remove(done);
-// };
+beforeEach(async () => {
+  await Trip.create({
+    id: 101,
+    name: 'Iconic North',
+    season: 'Summer',
+    year: 2020,
+    imageUrl: 'https://www.trafalgar.com/-/media/Project/Trafalgar/Product/hero-images/Iconic-North-Summer-2020-w.webp?smartCrop=1&centreCrop=1&w=2600&h=800',
+    days: 7,
+    country: 'New Zealand',
+    cities: ['Auckland', 'Tauranga', 'Matamata', 'Rotorua', 'Wellington', 'Blenheim', 'Picton'],
+    descriptions: ['BUBBLING MUD POOLS AND MĀORI CULTURE DEFINE THIS MEMORABLE ENCOUNTER WITH NEW ZEALANDS NORTH. EXPLORE AUCKLAND, ROTORUA AND WELLINGTON, WITH A STOP FOR LUNCH WITH A RETIRED CHAMPION JOCKEY.', 'Bubbling mud pools and Māori culture define this memorable encounter with New Zealands north. Explore Auckland, Rotorua and Wellington, with a stop for lunch with a retired champion jockey.'],
+    nights: 6,
+    meals: { breakfasts: 6, lunches: 1, dinners: 3 },
+    the_trafalgar_difference: ['Connect with locals', 'dive into culture'],
+    sightseeing_highlights: ['city tour', 'orientation', 'visit', 'view'],
+    travel_highlights: ['audio headsets', 'handcrafted highlights'],
+  });
+});
 
+afterEach(async () => {
+  await Trip.deleteOne({ name: 'Iconic North' });
+});
 
-// // test trip for database:
-// const iconicNorth = new Trip ({
-//   id: 1,
-//   name: 'Iconic North',
-//   season: 'Summer',
-//   year: 2020,
-//   imageUrl: 'https://www.trafalgar.com/-/media/Project/Trafalgar/Product/hero-images/Iconic-North-Summer-2020-w.webp?smartCrop=1&centreCrop=1&w=2600&h=800',
-//   days: 7,
-//   country: 'New Zealand',
-//   cities: ['Auckland', 'Tauranga', 'Matamata', 'Rotorua', 'Wellington', 'Blenheim', 'Picton'],
-//   descriptions: ['BUBBLING MUD POOLS AND MĀORI CULTURE DEFINE THIS MEMORABLE ENCOUNTER WITH NEW ZEALANDS NORTH. EXPLORE AUCKLAND, ROTORUA AND WELLINGTON, WITH A STOP FOR LUNCH WITH A RETIRED CHAMPION JOCKEY.', 'Bubbling mud pools and Māori culture define this memorable encounter with New Zealands north. Explore Auckland, Rotorua and Wellington, with a stop for lunch with a retired champion jockey.'],
-//   nights: 6,
-//   meals: { breakfasts: 6, lunches: 1, dinners: 3 },
-//   the_trafalgar_difference: ['Connect with locals', 'dive into culture'],
-//   sightseeing_highlights: ['city tour', 'orientation', 'visit', 'view'],
-//   travel_highlights: ['audio headsets', 'handcrafted highlights'],
-// });
-
-// iconicNorth.save();
-
-// describe('Insert test trip into db', () => {
-//   let server;
-//   before((done) => {
-// //     if (mongoose.connection.db) {
-// //       return done();
-// //     }
-// //     mongoose.connect(dbURI, done);
-// //   });
-// //   beforeEach((done) => {
-// //     server = app.listen(3000, () => {
-// //       clearDB(() => {
-// //         Trip.create(iconicNorth, done);
-// //       });
-// //     });
-// //   });
-// //   afterEach(() => {
-// //     server.close();
-//   });
-// });
+afterAll(async (done) => {
+  await mongoose.connection.collections.trips.deleteMany(done);
+});
 
 describe('server api', () => {
-  it('gets all 100 trips in the database', async (done) => {
+  it('gets all trips in the database', async (done) => {
     const response = await request.get('/api/trips');
     expect(response.statusCode).toBe(200);
-    expect(response.body.length).toBe(100);
+    expect(response.body.length).toBe(1); // database should contain 1 trip after running sample trip
     done();
   });
   it('gets a trip with a given id when passed that number as a parameter', async (done) => {
-    const response = await request.get('/api/trips/5');
+    const response = await request.get('/api/trips/101');
     expect(response.statusCode).toBe(200);
-    expect(response.body.length).toBe(1);
-    expect(response.body[0].id).toBe(5);
+    expect(response.body.length).toBe(1); // response should only include one trip
+    expect(response.body[0].id).toBe(101); // that trip's id should be 101 as described when inserted
+    expect(response.body[0].name).toBe('Iconic North'); // its name should be Iconic North
     done();
   });
 });

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,0 +1,73 @@
+/* eslint-disable no-undef */
+// const mongodb = require('mongoose');
+const supertest = require('supertest');
+const chai = require('chai');
+
+const { expect } = chai;
+
+const app = require('../server/index.js');
+// const Trip = require('../db/schema.js');
+
+const request = supertest(app);
+
+// const dbURI = 'mongodb://localhost/Trafalgartest';
+
+// const clearDB = function (done) {
+//   mongoose.connection.collections.trips.remove(done);
+// };
+
+
+// // test trip for database:
+// const iconicNorth = new Trip ({
+//   id: 1,
+//   name: 'Iconic North',
+//   season: 'Summer',
+//   year: 2020,
+//   imageUrl: 'https://www.trafalgar.com/-/media/Project/Trafalgar/Product/hero-images/Iconic-North-Summer-2020-w.webp?smartCrop=1&centreCrop=1&w=2600&h=800',
+//   days: 7,
+//   country: 'New Zealand',
+//   cities: ['Auckland', 'Tauranga', 'Matamata', 'Rotorua', 'Wellington', 'Blenheim', 'Picton'],
+//   descriptions: ['BUBBLING MUD POOLS AND MĀORI CULTURE DEFINE THIS MEMORABLE ENCOUNTER WITH NEW ZEALANDS NORTH. EXPLORE AUCKLAND, ROTORUA AND WELLINGTON, WITH A STOP FOR LUNCH WITH A RETIRED CHAMPION JOCKEY.', 'Bubbling mud pools and Māori culture define this memorable encounter with New Zealands north. Explore Auckland, Rotorua and Wellington, with a stop for lunch with a retired champion jockey.'],
+//   nights: 6,
+//   meals: { breakfasts: 6, lunches: 1, dinners: 3 },
+//   the_trafalgar_difference: ['Connect with locals', 'dive into culture'],
+//   sightseeing_highlights: ['city tour', 'orientation', 'visit', 'view'],
+//   travel_highlights: ['audio headsets', 'handcrafted highlights'],
+// });
+
+// iconicNorth.save();
+
+// describe('Insert test trip into db', () => {
+//   let server;
+//   before((done) => {
+// //     if (mongoose.connection.db) {
+// //       return done();
+// //     }
+// //     mongoose.connect(dbURI, done);
+// //   });
+// //   beforeEach((done) => {
+// //     server = app.listen(3000, () => {
+// //       clearDB(() => {
+// //         Trip.create(iconicNorth, done);
+// //       });
+// //     });
+// //   });
+// //   afterEach(() => {
+// //     server.close();
+//   });
+// });
+
+describe('server api', () => {
+  it('gets all the trips in the database', (done) => {
+    request
+      .get('/api/trips')
+      .expect(200);
+    done();
+  });
+  it('gets a trip when passed a numerical id as a parameter', (done) => {
+    request
+      .get('/api/trips/5')
+      .expect(200);
+    done();
+  });
+});


### PR DESCRIPTION
I set the Jest script to 'forceExit' due to persistent timeout warnings while testing (despite using 'done'), but otherwise it's working as expected to check API with mock data.